### PR TITLE
REVIEW-ONLY-PR: add user-profile admin-ui test to realm_settings_user_profile_enabled_spec.ts

### DIFF
--- a/js/apps/admin-ui/cypress/e2e/realm_settings_user_profile_enabled.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/realm_settings_user_profile_enabled.spec.ts
@@ -24,45 +24,57 @@ const getUserProfileTab = () => userProfileTab.goToTab();
 const getAttributesTab = () => userProfileTab.goToAttributesTab();
 const getAttributesGroupTab = () => userProfileTab.goToAttributesGroupTab();
 const getJsonEditorTab = () => userProfileTab.goToJsonEditorTab();
-const clickCreateAttributeButton = () =>
-  userProfileTab.createAttributeButtonClick();
+
+const usernameAttributeName = "username";
+const emailAttributeName = "email";
+
+let defaultUserProfile;
 
 describe("User profile tabs", () => {
   const realmName = "Realm_" + uuid();
   const attributeName = "Test";
 
-  before(() => adminClient.createRealm(realmName));
-  after(() => adminClient.deleteRealm(realmName));
+  before(() => {
+    cy.wrap(null).then(async () => {
+      await adminClient.createRealm(realmName);
+
+      defaultUserProfile = await adminClient.getUserProfile(realmName);
+    });
+  });
+
+  after(() =>
+    cy.wrap(null).then(async () => await adminClient.deleteRealm(realmName)),
+  );
 
   beforeEach(() => {
     loginPage.logIn();
     keycloakBefore();
+    cy.wrap(null).then(async () => {
+      await adminClient.updateUserProfile(realmName, defaultUserProfile);
+
+      await adminClient.updateRealm(realmName, {
+        registrationEmailAsUsername: false,
+        editUsernameAllowed: false,
+      });
+    });
+
     sidebarPage.goToRealm(realmName);
     sidebarPage.goToRealmSettings();
-  });
-
-  afterEach(() => {
-    sidebarPage.goToRealmSettings();
-    sidebarPage.waitForPageLoad();
-    realmSettingsPage.goToLoginTab();
-    cy.wait(1000);
-    cy.findByTestId("email-as-username-switch").uncheck({ force: true });
-    cy.findByTestId("edit-username-switch").uncheck({ force: true });
   });
 
   describe("Attributes sub tab tests", () => {
     it("Goes to create attribute page", () => {
       getUserProfileTab();
       getAttributesTab();
-      clickCreateAttributeButton();
+      userProfileTab.clickOnCreateAttributeButton();
     });
 
     it("Completes new attribute form and performs cancel", () => {
       getUserProfileTab();
       getAttributesTab();
-      clickCreateAttributeButton();
       userProfileTab
-        .createAttribute(attributeName, "Test display name")
+        .clickOnCreateAttributeButton()
+        .setAttributeNames(attributeName, "Test display name")
         .cancelAttributeCreation()
         .checkElementNotInList(attributeName);
     });
@@ -70,13 +82,11 @@ describe("User profile tabs", () => {
     it("Completes new attribute form and performs submit", () => {
       getUserProfileTab();
       getAttributesTab();
-      clickCreateAttributeButton();
       userProfileTab
-        .createAttribute(attributeName, "Display name")
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
-      );
+        .clickOnCreateAttributeButton()
+        .setAttributeNames(attributeName, "Display name")
+        .saveAttributeCreation()
+        .assertNotificationSaved();
     });
 
     it("Modifies existing attribute and performs save", () => {
@@ -85,18 +95,20 @@ describe("User profile tabs", () => {
       userProfileTab
         .selectElementInList(attributeName)
         .editAttribute("Edited display name")
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
-      );
+        .saveAttributeCreation()
+        .assertNotificationSaved();
     });
 
     it("Adds and removes validator to/from existing attribute and performs save", () => {
       getUserProfileTab();
       getAttributesTab();
-      userProfileTab.selectElementInList(attributeName).cancelAddingValidator();
-      userProfileTab.addValidator();
-      cy.get('tbody [data-label="Validator name"]').contains("email");
+      userProfileTab
+        .selectElementInList(attributeName)
+        .cancelAddingValidator(emailAttributeName);
+      userProfileTab.addValidator(emailAttributeName);
+      cy.get('tbody [data-label="Validator name"]').contains(
+        emailAttributeName,
+      );
 
       userProfileTab.cancelRemovingValidator();
       userProfileTab.removeValidator();
@@ -106,15 +118,16 @@ describe("User profile tabs", () => {
 
   describe("Attribute groups sub tab tests", () => {
     it("Deletes an attributes group", () => {
+      const group = "Test";
       cy.wrap(null).then(() =>
         adminClient.patchUserProfile(realmName, {
-          groups: [{ name: "Test" }],
+          groups: [{ name: group }],
         }),
       );
 
       getUserProfileTab();
       getAttributesGroupTab();
-      listingPage.deleteItem("Test");
+      listingPage.deleteItem(group);
       modalUtils.confirmModal();
       listingPage.checkEmptyList();
     });
@@ -126,9 +139,9 @@ describe("User profile tabs", () => {
   {
     "attributes": [
       {
-  "name": "email"{downArrow},
+  "name": "${emailAttributeName}"{downArrow},
       {
-  "name": "username",
+  "name": "${usernameAttributeName}",
   "validations": {
     "length": {
     "min": 3,
@@ -146,274 +159,281 @@ describe("User profile tabs", () => {
     });
   });
 
-  describe("Check attribute presence when creating a user based on email as username and edit username configs enabled/disabled", () => {
+  describe("Check attributes are displayed and editable on user create/edit", () => {
     it("Checks that not required attribute is not present when user is created with email as username and edit username set to disabled", () => {
+      const attrName = "newAttribute1";
+
       getUserProfileTab();
-      getAttributesTab();
-      clickCreateAttributeButton();
-      userProfileTab
-        .createAttributeNotRequiredWithoutPermissions(
-          "newAttribute1",
-          "newAttribute1",
-        )
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setNoAttributePermissions(),
       );
+
       sidebarPage.goToRealmSettings();
       realmSettingsPage.goToLoginTab();
       cy.wait(1000);
-      cy.findByTestId("email-as-username-switch").should("have.value", "off");
-      cy.findByTestId("edit-username-switch").should("have.value", "off");
+      realmSettingsPage
+        .assertSwitch(realmSettingsPage.emailAsUsernameSwitch, false)
+        .assertSwitch(realmSettingsPage.editUsernameSwitch, false);
+
       // Create user
       sidebarPage.goToUsers();
       cy.wait(1000);
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser7");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute1")
-        .should("not.exist");
+      createUserPage
+        .goToCreateUser()
+        .assertAttributeFieldExists(attrName, false)
+        .setUsername("testuser7")
+        .create()
+        .assertNotificationCreated()
+        .assertAttributeFieldExists(attrName, false);
+
       sidebarPage.goToRealmSettings();
       getUserProfileTab();
       getAttributesTab();
-      listingPage.deleteItem("newAttribute1");
+      listingPage.deleteItem(attrName);
       modalUtils.confirmModal();
       masthead.checkNotificationMessage("Attribute deleted");
     });
+
     it("Checks that not required attribute is not present when user is created/edited with email as username enabled", () => {
+      const attrName = "newAttribute2";
+
       getUserProfileTab();
-      getAttributesTab();
-      clickCreateAttributeButton();
-      userProfileTab
-        .createAttributeNotRequiredWithoutPermissions(
-          "newAttribute2",
-          "newAttribute2",
-        )
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setNoAttributePermissions(),
       );
+
       sidebarPage.goToRealmSettings();
       realmSettingsPage.goToLoginTab();
       cy.wait(1000);
-      cy.findByTestId("email-as-username-switch").check({ force: true });
-      cy.findByTestId("email-as-username-switch").should("have.value", "on");
-      cy.findByTestId("edit-username-switch").should("have.value", "off");
+      realmSettingsPage
+        .setSwitch(realmSettingsPage.emailAsUsernameSwitch, true)
+        .assertSwitch(realmSettingsPage.emailAsUsernameSwitch, true)
+        .assertSwitch(realmSettingsPage.editUsernameSwitch, false);
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("email").type("testuser8@gmail.com");
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute2")
-        .should("not.exist");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
+      createUserPage
+        .goToCreateUser()
+        .setAttributeValue(emailAttributeName, "testuser8@gmail.com")
+        .assertAttributeFieldExists(attrName, false)
+        .create()
+        .assertNotificationCreated();
+
       // Edit user
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute2")
-        .should("not.exist");
-      cy.findByTestId("email").clear();
-      cy.findByTestId("email").type("testuser9@gmail.com");
-      cy.findByTestId("save-user").click();
-      masthead.checkNotificationMessage("The user has been saved");
-      sidebarPage.goToRealmSettings();
-      getUserProfileTab();
-      getAttributesTab();
-      listingPage.deleteItem("newAttribute2");
-      modalUtils.confirmModal();
-      masthead.checkNotificationMessage("Attribute deleted");
+      createUserPage
+        .assertAttributeFieldExists(attrName, false)
+        .setAttributeValue(emailAttributeName, "testuser9@gmail.com")
+        .update()
+        .assertNotificationUpdated();
     });
+
     it("Checks that not required attribute with permissions to view/edit is present when user is created", () => {
+      const attrName = "newAttribute3";
+
       getUserProfileTab();
-      getAttributesTab();
-      clickCreateAttributeButton();
-      userProfileTab
-        .createAttributeNotRequiredWithPermissions(
-          "newAttribute3",
-          "newAttribute3",
-        )
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setAllAttributePermissions(),
       );
+
       sidebarPage.goToRealmSettings();
       realmSettingsPage.goToLoginTab();
       cy.wait(1000);
-      cy.findByTestId("email-as-username-switch").should("have.value", "off");
-      cy.findByTestId("edit-username-switch").should("have.value", "off");
+      realmSettingsPage
+        .assertSwitch(realmSettingsPage.emailAsUsernameSwitch, false)
+        .assertSwitch(realmSettingsPage.editUsernameSwitch, false);
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser10");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute3")
-        .should("exist");
-      sidebarPage.goToRealmSettings();
-      getUserProfileTab();
-      getAttributesTab();
-      listingPage.deleteItem("newAttribute3");
-      modalUtils.confirmModal();
-      masthead.checkNotificationMessage("Attribute deleted");
+      createUserPage
+        .goToCreateUser()
+        .assertAttributeFieldExists(attrName, true)
+        .setUsername("testuser10")
+        .create()
+        .assertNotificationCreated()
+        .assertAttributeFieldExists(attrName, true);
     });
-    //TODO this test doesn't seem to pass on CI
-    it.skip("Checks that required attribute with permissions to view/edit is present and required when user is created", () => {
+
+    it("Checks that required attribute with permissions to view/edit is present and required when user is created", () => {
+      const attrName = "newAttribute4";
+
       getUserProfileTab();
-      getAttributesTab();
-      clickCreateAttributeButton();
-      userProfileTab
-        .createAttributeRequiredWithPermissions(
-          "newAttribute4",
-          "newAttribute4",
-        )
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setAllAttributePermissions().setAttributeRequired(),
       );
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser11");
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute4")
-        .should("exist");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage(
-        "Could not create user: Please specify attribute newAttribute4.",
-      );
-      sidebarPage.goToRealmSettings();
-      getUserProfileTab();
-      getAttributesTab();
-      listingPage.deleteItem("newAttribute4");
-      modalUtils.confirmModal();
-      masthead.checkNotificationMessage("Attribute deleted");
+      createUserPage
+        .goToCreateUser()
+        .assertAttributeLabel(attrName, attrName)
+        .setUsername("testuser11")
+        .create()
+        .assertValidationErrorRequired(attrName);
+
+      createUserPage
+        .setAttributeValue(attrName, "MyAttribute")
+        .create()
+        .assertNotificationCreated();
     });
+
     it("Checks that required attribute with permissions to view/edit is accepted when user is created", () => {
+      const attrName = "newAttribute5";
+
       getUserProfileTab();
-      getAttributesTab();
-      clickCreateAttributeButton();
-      userProfileTab
-        .createAttributeRequiredWithPermissions(
-          "newAttribute5",
-          "newAttribute5",
-        )
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setAllAttributePermissions().setAttributeRequired(),
       );
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser12");
-      cy.get(".pf-c-form__label-text")
-        .contains("newAttribute5")
-        .should("exist");
-      cy.findByTestId("newAttribute5").type("MyAttribute");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
-      sidebarPage.goToRealmSettings();
-      getUserProfileTab();
-      getAttributesTab();
-      listingPage.deleteItem("newAttribute5");
-      modalUtils.confirmModal();
-      masthead.checkNotificationMessage("Attribute deleted");
+      createUserPage
+        .goToCreateUser()
+        .assertAttributeLabel(attrName, attrName)
+        .setUsername("testuser12")
+        .setAttributeValue(attrName, "MyAttribute")
+        .create()
+        .assertNotificationCreated();
     });
+
     it("Checks that attribute group is visible when user with existing attribute is created", () => {
+      const group = "personalInfo";
+
       getUserProfileTab();
-      getAttributesGroupTab();
-      cy.findAllByTestId("no-attributes-groups-empty-action").click();
-      userProfileTab.createAttributeGroup("personalInfo", "personalInfo");
-      userProfileTab.saveAttributesGroupCreation();
+      getAttributesGroupTab()
+        .clickOnCreatesAttributesGroupButton()
+        .createAttributeGroup(group, group)
+        .saveAttributesGroupCreation();
 
       getAttributesTab();
-      userProfileTab.selectElementInList("username");
-      cy.get("#kc-attributeGroup").click();
-      cy.get("button.pf-c-select__menu-item").contains("personalInfo").click();
-      userProfileTab.saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
-      );
+      userProfileTab
+        .selectElementInList(usernameAttributeName)
+        .setAttributeGroup(group)
+        .saveAttributeCreation()
+        .assertNotificationSaved();
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser14");
-      cy.get("h1#personalinfo").should("have.text", "personalInfo");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
+      createUserPage
+        .goToCreateUser()
+        .assertGroupDisplayName(group, group)
+        .setUsername("testuser14")
+        .create()
+        .assertNotificationCreated();
 
       sidebarPage.goToRealmSettings();
       getUserProfileTab();
       getAttributesTab();
-      userProfileTab.selectElementInList("username");
-      cy.get("#kc-attributeGroup").click();
-      cy.get("button.pf-c-select__menu-item").contains("None").click();
-      userProfileTab.saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      userProfileTab
+        .selectElementInList(usernameAttributeName)
+        .resetAttributeGroup()
+        .saveAttributeCreation()
+        .assertNotificationSaved();
+    });
+
+    it("Checks that attribute group is visible when user with a new attribute is created", () => {
+      const group = "contact";
+      const attrName = "address";
+
+      getUserProfileTab();
+      getAttributesGroupTab()
+        .clickOnCreatesAttributesGroupButton()
+        .createAttributeGroup(group, group)
+        .saveAttributesGroupCreation();
+
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer.setAllAttributePermissions(),
       );
 
-      getAttributesGroupTab();
-      listingPage.deleteItem("personalInfo");
-      modalUtils.confirmModal();
-      listingPage.checkEmptyList();
-    });
-    it("Checks that attribute group is visible when user with a new attribute is created", () => {
-      getUserProfileTab();
-      getAttributesGroupTab();
-      cy.findAllByTestId("no-attributes-groups-empty-action").click();
-      userProfileTab.createAttributeGroup("contact", "contact");
-      userProfileTab.saveAttributesGroupCreation();
-      getAttributesTab();
-      clickCreateAttributeButton();
       userProfileTab
-        .createAttributeNotRequiredWithPermissions("address", "address")
-        .saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
-      );
-      userProfileTab.selectElementInList("address");
-      cy.get("#kc-attributeGroup").click();
-      cy.get("button.pf-c-select__menu-item").contains("contact").click();
-      userProfileTab.saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
-      );
+        .selectElementInList(attrName)
+        .setAttributeGroup(group)
+        .saveAttributeCreation()
+        .assertNotificationSaved();
+
       // Create user
       sidebarPage.goToUsers();
-      createUserPage.goToCreateUser();
-      cy.findByTestId("username").type("testuser13");
-      cy.get("h1#contact").should("have.text", "contact");
-      cy.get(".pf-c-form__label-text").contains("address").should("exist");
-      cy.findByTestId("address").type("MyNewAddress1");
-      cy.findByTestId("create-user").click();
-      masthead.checkNotificationMessage("The user has been created");
-      cy.findByTestId("address").should("have.value", "MyNewAddress1");
+      const initialAttrValue = "MyNewAddress1";
+      createUserPage
+        .goToCreateUser()
+        .assertGroupDisplayName(group, group)
+        .assertAttributeLabel(attrName, attrName)
+        .setUsername("testuser13")
+        .setAttributeValue(attrName, initialAttrValue)
+        .create()
+        .assertNotificationCreated()
+        .assertAttributeValue(attrName, initialAttrValue);
 
       // Edit attribute
-      cy.findByTestId("address").clear();
-      cy.findByTestId("address").type("MyNewAddress2");
-      cy.findByTestId("save-user").click();
-      masthead.checkNotificationMessage("The user has been saved");
-      cy.findByTestId("address").should("have.value", "MyNewAddress2");
+      const newAttrValue = "MyNewAddress2";
+      createUserPage
+        .setAttributeValue(attrName, newAttrValue)
+        .update()
+        .assertNotificationUpdated()
+        .assertAttributeValue(attrName, newAttrValue);
 
       sidebarPage.goToRealmSettings();
       getUserProfileTab();
       getAttributesTab();
-      userProfileTab.selectElementInList("address");
-      cy.get("#kc-attributeGroup").click();
-      cy.get("button.pf-c-select__menu-item").contains("None").click();
-      userProfileTab.saveAttributeCreation();
-      masthead.checkNotificationMessage(
-        "Success! User Profile configuration has been saved.",
+      userProfileTab
+        .selectElementInList(attrName)
+        .resetAttributeGroup()
+        .saveAttributeCreation()
+        .assertNotificationSaved();
+    });
+
+    it("Checks that attribute with select-annotation is displayed and editable when user is created/edited", () => {
+      const userName = "select-test-user";
+      const attrName = "select-test-attr";
+      const opt1 = "opt1";
+      const opt2 = "opt2";
+      const supportedOptions = [opt1, opt2];
+
+      getUserProfileTab();
+      createAttributeDefinition(attrName, (attrConfigurer) =>
+        attrConfigurer
+          .setAllAttributePermissions()
+          .clickAddValidator()
+          .selectValidatorType("options")
+          .setListFieldValues("options", supportedOptions)
+          .clickSave(),
       );
 
-      getAttributesGroupTab();
-      listingPage.deleteItem("contact");
-      modalUtils.confirmModal();
-      listingPage.checkEmptyList();
+      // Create user
+      sidebarPage.goToUsers();
+      createUserPage
+        .goToCreateUser()
+        .assertAttributeLabel(attrName, attrName)
+        .assertAttributeSelect(attrName, supportedOptions, "")
+        .setUsername(userName)
+        .setAttributeValueOnSelect(attrName, opt1)
+        .create()
+        .assertNotificationCreated()
+        .assertAttributeLabel(attrName, attrName)
+        .assertAttributeSelect(attrName, supportedOptions, opt1);
+
+      // Edit attribute
+      createUserPage
+        .setAttributeValueOnSelect(attrName, opt2)
+        .update()
+        .assertNotificationUpdated()
+        .assertAttributeLabel(attrName, attrName)
+        .assertAttributeSelect(attrName, supportedOptions, opt2);
     });
+
+    function createAttributeDefinition(
+      attrName: string,
+      attrConfigurer?: (attrConfigurer: UserProfile) => void,
+    ) {
+      userProfileTab
+        .goToAttributesTab()
+        .clickOnCreateAttributeButton()
+        .setAttributeNames(attrName, attrName);
+
+      if (attrConfigurer) {
+        attrConfigurer(userProfileTab);
+      }
+
+      userProfileTab.saveAttributeCreation().assertNotificationSaved();
+    }
   });
 });

--- a/js/apps/admin-ui/cypress/e2e/users_test.spec.ts
+++ b/js/apps/admin-ui/cypress/e2e/users_test.spec.ts
@@ -73,7 +73,7 @@ describe("User creation", () => {
 
     createUserPage.createUser(itemId);
 
-    createUserPage.save();
+    createUserPage.create();
 
     masthead.checkNotificationMessage("The user has been created");
   });
@@ -95,7 +95,7 @@ describe("User creation", () => {
 
     createUserPage.joinGroups();
 
-    createUserPage.save();
+    createUserPage.create();
 
     masthead.checkNotificationMessage("The user has been created");
   });
@@ -109,7 +109,7 @@ describe("User creation", () => {
     createUserPage.createUser(itemIdWithCred);
 
     userDetailsPage.fillUserData();
-    createUserPage.save();
+    createUserPage.create();
     masthead.checkNotificationMessage("The user has been created");
     sidebarPage.waitForPageLoad();
 
@@ -493,7 +493,7 @@ describe("User creation", () => {
       createUserPage.goToCreateUser();
       createUserPage.createUser(a11yUser);
       userDetailsPage.fillUserData();
-      createUserPage.save();
+      createUserPage.create();
       cy.checkA11y();
     });
 

--- a/js/apps/admin-ui/cypress/support/forms/FormValidation.ts
+++ b/js/apps/admin-ui/cypress/support/forms/FormValidation.ts
@@ -1,26 +1,27 @@
 export default class FormValidation {
   static assertRequired(chain: Cypress.Chainable<JQuery<HTMLElement>>) {
-    return this.#getHelperText(chain).should("have.text", "Required field");
+    return this.assertMessage(chain, "Required field");
+  }
+
+  static assertMessage(
+    chain: Cypress.Chainable<JQuery<HTMLElement>>,
+    expectedMessage: string,
+  ) {
+    return this.#getHelperText(chain).should("have.text", expectedMessage);
   }
 
   static assertMinValue(
     chain: Cypress.Chainable<JQuery<HTMLElement>>,
     minValue: number,
   ) {
-    this.#getHelperText(chain).should(
-      "have.text",
-      `Must be greater than ${minValue}`,
-    );
+    this.assertMessage(chain, `Must be greater than ${minValue}`);
   }
 
   static assertMaxValue(
     chain: Cypress.Chainable<JQuery<HTMLElement>>,
     maxValue: number,
   ) {
-    this.#getHelperText(chain).should(
-      "have.text",
-      `Must be less than ${maxValue}`,
-    );
+    this.assertMessage(chain, `Must be less than ${maxValue}`);
   }
 
   static #getHelperText(chain: Cypress.Chainable<JQuery<HTMLElement>>) {

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/RealmSettingsPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/RealmSettingsPage.ts
@@ -71,6 +71,7 @@ export default class RealmSettingsPage extends CommonPage {
   forgotPwdSwitch = "forgot-pw-switch";
   rememberMeSwitch = "remember-me-switch";
   emailAsUsernameSwitch = "email-as-username-switch";
+  editUsernameSwitch = "edit-username-switch";
   loginWithEmailSwitch = "login-with-email-switch";
   duplicateEmailsSwitch = "duplicate-emails-switch";
   verifyEmailSwitch = "verify-email-switch";
@@ -443,6 +444,22 @@ export default class RealmSettingsPage extends CommonPage {
     cy.findByTestId(switchName).click({ force: true });
     if (waitFor) {
       cy.wait("@load");
+    }
+
+    return this;
+  }
+
+  assertSwitch(switchName: string, on: boolean) {
+    cy.findByTestId(switchName).should("have.value", on ? "on" : "off");
+
+    return this;
+  }
+
+  setSwitch(switchName: string, on: boolean) {
+    if (on) {
+      cy.findByTestId(switchName).check({ force: true });
+    } else {
+      cy.findByTestId(switchName).uncheck({ force: true });
     }
 
     return this;

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/ValidatorConfigDialogue.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/realm_settings/ValidatorConfigDialogue.ts
@@ -1,0 +1,46 @@
+import UserProfile from "./UserProfile";
+import Select from "../../../../forms/Select";
+
+export default class ValidatorConfigDialogue {
+  readonly #validatorSelector = "#validator";
+  readonly #saveValidatorButton = "save-validator-role-button";
+  readonly #cancelValidatorButton: "cancel-validator-role-button";
+  readonly #addValue = "addValue";
+
+  readonly userProfile: UserProfile;
+
+  constructor(userProfile: UserProfile) {
+    this.userProfile = userProfile;
+  }
+
+  clickSave() {
+    cy.findByTestId(this.#saveValidatorButton).click();
+
+    return this.userProfile;
+  }
+
+  selectValidatorType(type: string) {
+    Select.selectItem(cy.get(this.#validatorSelector), type);
+
+    return this;
+  }
+
+  setListFieldValues(fieldName: string, values: string[]) {
+    for (let i = 0; i < values.length; i++) {
+      if (i != 0) {
+        cy.findByTestId(this.#addValue).click();
+      }
+
+      const testId = `config.options${i}`;
+      cy.findByTestId(testId).clear().type(values[i]);
+    }
+
+    return this;
+  }
+
+  clickCancel() {
+    cy.findByTestId(this.#cancelValidatorButton).click();
+
+    return this.userProfile;
+  }
+}

--- a/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/CreateUserPage.ts
+++ b/js/apps/admin-ui/cypress/support/pages/admin-ui/manage/users/CreateUserPage.ts
@@ -1,34 +1,32 @@
+import Masthead from "../../Masthead";
+import FormValidation from "../../../../forms/FormValidation";
+
 export default class CreateUserPage {
-  usernameInput: string;
+  readonly masthead = new Masthead();
+
   usersEmptyState: string;
   emptyStateCreateUserBtn: string;
   addUserBtn: string;
   joinGroupsBtn: string;
   joinBtn: string;
+  createBtn: string;
   saveBtn: string;
   cancelBtn: string;
 
   constructor() {
-    this.usernameInput = "#username";
-
     this.usersEmptyState = "empty-state";
     this.emptyStateCreateUserBtn = "no-users-found-empty-action";
     this.addUserBtn = "add-user";
     this.joinGroupsBtn = "join-groups-button";
     this.joinBtn = "join-button";
-    this.saveBtn = "create-user";
+    this.createBtn = "create-user";
+    this.saveBtn = "save-user";
     this.cancelBtn = "cancel-create-user";
   }
 
   //#region General Settings
   createUser(username: string) {
-    cy.get(this.usernameInput).clear();
-
-    if (username) {
-      cy.get(this.usernameInput).type(username);
-    }
-
-    return this;
+    return this.setUsername(username);
   }
 
   goToCreateUser() {
@@ -55,8 +53,156 @@ export default class CreateUserPage {
     return this;
   }
 
-  save() {
+  create() {
+    cy.findByTestId(this.createBtn).click();
+
+    return this;
+  }
+
+  update() {
     cy.findByTestId(this.saveBtn).click();
+
+    return this;
+  }
+
+  assertAttributeValue(attrName: string, expectedValue: string) {
+    cy.findByTestId(attrName).should("have.value", expectedValue);
+
+    return this;
+  }
+
+  assertAttributeFieldExists(attrName: string, shouldExist: boolean) {
+    const chainer = shouldExist ? "exist" : "not.exist";
+    cy.findByTestId(attrName).should(chainer);
+
+    return this;
+  }
+
+  assertAttributeSelect(
+    attrName: string,
+    expectedOptions: string[],
+    expectedValue: string,
+  ) {
+    this.#getSelectFieldButton(attrName).should(
+      "have.class",
+      "pf-c-select__toggle",
+    );
+
+    const valueToCheck = expectedValue ? expectedValue : "Choose...";
+    this.#getSelectFieldButton(attrName)
+      .find(".pf-c-select__toggle-text")
+      .invoke("text")
+      .should("eq", valueToCheck);
+
+    this.#withSelectExpanded(attrName, () => {
+      this.#getSelectOptions(attrName)
+        .should("have.length", expectedOptions.length)
+        .each(($option, index) =>
+          cy.wrap($option).should("have.text", expectedOptions[index]),
+        );
+    });
+
+    return this;
+  }
+
+  #getSelectFieldButton(attrName: string) {
+    const attrSelector = `#${attrName}`;
+    return cy.get(attrSelector);
+  }
+
+  #getSelectOptions(attrName: string) {
+    return this.#getSelectFieldButton(attrName)
+      .parent()
+      .find(".pf-c-select__menu-item");
+  }
+
+  #clickSelectFieldButton(
+    attrName: string,
+    condition?: (expanded: boolean) => boolean,
+  ) {
+    return this.#getSelectFieldButton(attrName).then(($selectField) => {
+      const expanded = $selectField.attr("aria-expanded") === "true";
+      if (!condition || condition(expanded)) {
+        cy.wrap($selectField).click();
+      }
+    });
+  }
+
+  #withSelectExpanded(attrName: string, func: () => any) {
+    let expandNecessary = false;
+    this.#clickSelectFieldButton(attrName, (expanded) => {
+      expandNecessary = !expanded;
+      return expandNecessary;
+    });
+
+    func();
+
+    // click again on the dropdown to hide the values list, when necessary
+    this.#clickSelectFieldButton(attrName, () => expandNecessary);
+  }
+
+  assertAttributeLabel(attrName: string, expectedText: string) {
+    cy.get(`.pf-c-form__label[for='${attrName}'] .pf-c-form__label-text`)
+      .contains(expectedText)
+      .should("exist");
+
+    return this;
+  }
+
+  assertValidationErrorRequired(attrName: string) {
+    FormValidation.assertMessage(
+      cy.findByTestId(attrName),
+      `Please specify '${attrName}'.`,
+    );
+
+    return this;
+  }
+
+  assertGroupDisplayName(group: string, expectedDisplayName: string) {
+    cy.get(`h1#${group.toLowerCase()}`).should(
+      "have.text",
+      expectedDisplayName,
+    );
+
+    return this;
+  }
+
+  setAttributeValue(attrName: string, value: string) {
+    cy.findByTestId(attrName).clear().type(value);
+
+    return this;
+  }
+
+  setAttributeValueOnSelect(attrName: string, value: string) {
+    this.#withSelectExpanded(attrName, () => {
+      this.#getSelectOptions(attrName).contains(value).click();
+    });
+
+    return this;
+  }
+
+  setUsername(value: string) {
+    this.#getUsernameField().clear();
+
+    if (value) {
+      this.#getUsernameField().type(value);
+    }
+
+    return this;
+  }
+
+  #getUsernameField() {
+    return cy.findByTestId("username");
+  }
+
+  assertNotificationCreated() {
+    this.masthead.checkNotificationMessage("The user has been created");
+
+    return this;
+  }
+
+  assertNotificationUpdated() {
+    this.masthead.checkNotificationMessage("The user has been saved");
 
     return this;
   }

--- a/js/apps/admin-ui/cypress/support/util/AdminClient.ts
+++ b/js/apps/admin-ui/cypress/support/util/AdminClient.ts
@@ -245,6 +245,18 @@ class AdminClient {
     });
   }
 
+  async getUserProfile(realm: string) {
+    await this.#login();
+
+    return await this.#client.users.getProfile({ realm });
+  }
+
+  async updateUserProfile(realm: string, userProfile: UserProfileConfig) {
+    await this.#login();
+
+    await this.#client.users.updateProfile(merge(userProfile, { realm }));
+  }
+
   async patchUserProfile(realm: string, payload: UserProfileConfig) {
     await this.#login();
 

--- a/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupTab.tsx
+++ b/js/apps/admin-ui/src/realm-settings/user-profile/AttributesGroupTab.tsx
@@ -75,7 +75,11 @@ export const AttributesGroupTab = () => {
           <ToolbarItem>
             <Button
               component={(props) => (
-                <Link {...props} to={toNewAttributesGroup({ realm })} />
+                <Link
+                  data-testid="create-attributes-groups-action"
+                  {...props}
+                  to={toNewAttributesGroup({ realm })}
+                />
               )}
             >
               {t("createGroupText")}


### PR DESCRIPTION
add test named "Checks that attribute with select-annotation is displayed and editable when user is created/edited"

- refactor existing tests to use page objects, add new helper methods to page objects and use it in existing tests
- rename CreateUserPage#save() to #create(), and add a new method #update()
- add new test mentioned above
- re-enable test "Checks that required attribute with permissions to view/edit is present and required when user is created"
- stabilize realm_settings_user_profile_enabled.spec.ts by resetting the user-profile to default and resetting the realm attributes to default before each test

<!---
Please read https://github.com/keycloak/keycloak/blob/main/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
